### PR TITLE
Re-enable generation of a single appspec.yml file for all Lambda func…

### DIFF
--- a/codeBuild/buildspec.yml
+++ b/codeBuild/buildspec.yml
@@ -15,11 +15,9 @@ phases:
       - echo Build completed on `date`
       - pip install boto3 pyyaml python-hcl2
       - python3 codeBuild/generate_appspec.py
-      - echo Generated AppSpec files
-      - ls -la appspec-*.yml
 
 artifacts:
   files:
-    - appspec-*.yml
+    - appspec.yml
     - build/distributions/FryRankLambda.zip
   discard-paths: yes

--- a/codeBuild/generate_appspec.py
+++ b/codeBuild/generate_appspec.py
@@ -37,7 +37,8 @@ def generate_appspec(lambda_client=None, s3_client=None):
         lambda_client = boto3.client('lambda')
     lambda_functions = load_lambda_functions(s3_client)
     
-    # Process each function separately
+    # Create resources list for all functions
+    resources = []
     for key, function in lambda_functions.items():
         function_name = function['name']
         
@@ -50,8 +51,8 @@ def generate_appspec(lambda_client=None, s3_client=None):
             FunctionName=function_name
         )['Version']
         
-        # Create single resource for this function
-        resource = {
+        # Add function to resources
+        resources.append({
             function_name: {
                 'Type': 'AWS::Lambda::Function',
                 'Properties': {
@@ -61,19 +62,17 @@ def generate_appspec(lambda_client=None, s3_client=None):
                     'TargetVersion': new_version
                 }
             }
-        }
-        
-        # Create appspec for this function
-        appspec = {
-            'version': '0.0',
-            'Resources': [resource]
-        }
-        
-        # Write appspec file for this function
-        appspec_filename = f'appspec-{function_name}.yml'
-        with open(appspec_filename, 'w') as f:
-            f.write(yaml.dump(appspec, default_flow_style=False))
-        print(f"Generated {appspec_filename}")
+        })
+    
+    # Create single appspec with all functions
+    appspec = {
+        'version': '0.0',
+        'Resources': resources
+    }
+    
+    # Write appspec file
+    with open('appspec.yml', 'w') as f:
+        f.write(yaml.dump(appspec, default_flow_style=False))
 
 def main():
     generate_appspec()

--- a/codeBuild/test/test_generate_appspec.py
+++ b/codeBuild/test/test_generate_appspec.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from generate_appspec import generate_appspec, load_lambda_functions
 
 def validate_appspec():
-    print("\nValidating appspec files...")
+    print("\nValidating appspec.yml...")
     
     # Mock S3 response
     mock_s3 = MagicMock()
@@ -46,33 +46,37 @@ def validate_appspec():
     }
     mock_lambda.publish_version.return_value = {'Version': '2'}
     
-    # Generate the appspec files with mocked AWS clients
-    print("Generating appspec files...")
+    # Generate the appspec file with mocked AWS clients
+    print("Generating appspec.yml...")
     generate_appspec(lambda_client=mock_lambda, s3_client=mock_s3)
+    
+    # Verify the file was created
+    assert os.path.exists('appspec.yml'), "AppSpec file appspec.yml was not created"
+    
+    # Read and parse the generated file
+    with open('appspec.yml', 'r') as f:
+        generated = yaml.safe_load(f)
+    
+    # Validate structure
+    assert generated['version'] == '0.0', "Version should be 0.0"
+    assert 'Resources' in generated, "Should have Resources section"
     
     # Get all function names from mocked state
     lambda_functions = load_lambda_functions(s3_client=mock_s3)
+    expected_function_count = len(lambda_functions)
+    assert len(generated['Resources']) == expected_function_count, f"Should have exactly {expected_function_count} resources"
     
-    # Validate each function's appspec file
+    # Validate each function
     for key, function in lambda_functions.items():
         function_name = function['name']
-        appspec_filename = f'appspec-{function_name}.yml'
+        # Find the resource for this function
+        function_resource = None
+        for resource in generated['Resources']:
+            if function_name in resource:
+                function_resource = resource[function_name]
+                break
         
-        # Verify the file was created
-        assert os.path.exists(appspec_filename), f"AppSpec file {appspec_filename} was not created"
-        
-        # Read and parse the generated file
-        with open(appspec_filename, 'r') as f:
-            generated = yaml.safe_load(f)
-        
-        # Validate structure
-        assert generated['version'] == '0.0', f"Version should be 0.0 in {appspec_filename}"
-        assert 'Resources' in generated, f"Should have Resources section in {appspec_filename}"
-        assert len(generated['Resources']) == 1, f"Should have exactly 1 resource in {appspec_filename}"
-        
-        # Get the function resource
-        function_resource = generated['Resources'][0][function_name]
-        
+        assert function_resource is not None, f"Resource for {function_name} not found"
         assert function_resource['Type'] == 'AWS::Lambda::Function', f"Type should be AWS::Lambda::Function for {function_name}"
         
         properties = function_resource['Properties']
@@ -84,13 +88,11 @@ def validate_appspec():
         assert properties['Alias'] == 'Production', f"Alias should be Production for {function_name}"
         assert properties['CurrentVersion'] == '1', f"CurrentVersion should be 1 for {function_name}"
         assert properties['TargetVersion'] == '2', f"TargetVersion should be 2 for {function_name}"
-        
-        print(f"[PASS] Validation passed for {function_name}")
-        print(f"Generated AppSpec for {function_name}:")
-        print(yaml.dump(generated, default_flow_style=False))
-        print("---")
     
     print("[PASS] Validation passed for all functions")
+    print("Generated AppSpec:")
+    print(yaml.dump(generated, default_flow_style=False))
+    print("---")
 
 def main():
     validate_appspec()


### PR DESCRIPTION
Reverts back to previous behavior of putting all Lambda functions in one appspec file. This should work now as we will be creating one deployment group that deploys all the Lambda functions in the appspec file.